### PR TITLE
extension support so that other plugins can contribute to the plugin

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?eclipse version="3.4"?>
 <plugin>
+   <extension-point id="schemaprovider" name="Provide JSON Schema based on extension" schema="schema/schemaprovider.exsd"/>
 
    <extension
          id="sj.jsonSchemaValidationBuilder"

--- a/schema/schemaprovider.exsd
+++ b/schema/schemaprovider.exsd
@@ -1,0 +1,116 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Schema file written by PDE -->
+<schema targetNamespace="sj.jsonschemavalidation" xmlns="http://www.w3.org/2001/XMLSchema">
+<annotation>
+      <appinfo>
+         <meta.schema plugin="sj.jsonschemavalidation" id="schemaprovider" name="Provide JSON Schema based on extension"/>
+      </appinfo>
+      <documentation>
+         [Enter description of this extension point.]
+      </documentation>
+   </annotation>
+
+   <element name="extension">
+      <annotation>
+         <appinfo>
+            <meta.element />
+         </appinfo>
+      </annotation>
+      <complexType>
+         <sequence minOccurs="1" maxOccurs="unbounded">
+            <element ref="schemaprovider"/>
+         </sequence>
+         <attribute name="point" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="id" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="name" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appinfo>
+                  <meta.attribute translatable="true"/>
+               </appinfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <element name="schemaprovider">
+      <complexType>
+         <attribute name="id" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="name" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="class" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appinfo>
+                  <meta.attribute kind="java" basedOn=":sj.jsonschemavalidation.ISchemaProvider"/>
+               </appinfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="since"/>
+      </appinfo>
+      <documentation>
+         [Enter the first release in which this extension point appears.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="examples"/>
+      </appinfo>
+      <documentation>
+         [Enter extension point usage example here.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="apiinfo"/>
+      </appinfo>
+      <documentation>
+         [Enter API information here.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="implementation"/>
+      </appinfo>
+      <documentation>
+         [Enter information about supplied implementation of this extension point.]
+      </documentation>
+   </annotation>
+
+
+</schema>

--- a/src/sj/jsonschemavalidation/ISchemaProvider.java
+++ b/src/sj/jsonschemavalidation/ISchemaProvider.java
@@ -1,0 +1,10 @@
+package sj.jsonschemavalidation;
+
+import org.eclipse.core.resources.IFile;
+
+public interface ISchemaProvider {
+	static final String EXTENSION_ID = "sj.jsonschemavalidation.schemaprovider";
+	
+	String getSchemaFor(IFile file);
+	
+}

--- a/src/sj/jsonschemavalidation/builder/Activator.java
+++ b/src/sj/jsonschemavalidation/builder/Activator.java
@@ -1,8 +1,18 @@
 package sj.jsonschemavalidation.builder;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.core.runtime.IExtension;
+import org.eclipse.core.runtime.IExtensionPoint;
+import org.eclipse.core.runtime.IExtensionRegistry;
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.osgi.framework.BundleContext;
+
+import sj.jsonschemavalidation.ISchemaProvider;
 
 /**
  * The activator class controls the plug-in life cycle
@@ -14,6 +24,8 @@ public class Activator extends AbstractUIPlugin {
 
 	// The shared instance
 	private static Activator plugin;
+
+	private List<ISchemaProvider> schemaProviders = new ArrayList<>();
 	
 	/**
 	 * The constructor
@@ -28,6 +40,18 @@ public class Activator extends AbstractUIPlugin {
 	public void start(BundleContext context) throws Exception {
 		super.start(context);
 		plugin = this;
+		
+		IExtensionRegistry reg = Platform.getExtensionRegistry();
+		IExtensionPoint ep = reg.getExtensionPoint(ISchemaProvider.EXTENSION_ID);
+		IExtension[] extensions = ep.getExtensions();
+		if (extensions != null && extensions.length > 0)
+		{
+			for (IExtension extension : extensions)
+			{
+				ISchemaProvider provider = (ISchemaProvider)extension.getConfigurationElements()[0].createExecutableExtension("class");
+				schemaProviders.add(provider);
+			}
+		}
 	}
 
 	/*
@@ -57,5 +81,9 @@ public class Activator extends AbstractUIPlugin {
 	 */
 	public static ImageDescriptor getImageDescriptor(String path) {
 		return imageDescriptorFromPlugin(PLUGIN_ID, path);
+	}
+
+	public List<ISchemaProvider> getSchemaProviders() {
+		return Collections.unmodifiableList(schemaProviders);
 	}
 }


### PR DESCRIPTION
that for specific files a schema can be returned.

currently it is quite hard coded to use ".json" files and that those have a schema right besides it.

we don't want a schema file right besides it, We base everyting on a different extension ".spec" as an example
And all spec files have the same schema, Those spec files can be in many dirs. 

With this patch our plugin that uses the json validation plugin can just implement a eclipe extension point and contribute a class that test itself if it wants to give a schema based on the given file.

the last part in "checkAgainst" is for the latest json validation jar. You can skip this if needed.

(i did move the parse line numbers to that area also because that only has to be done if there are warnings/errors found)
